### PR TITLE
Added --kubeconfig flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,13 +25,15 @@ import (
 
 func main() {
 	client := client.NewClient()
-	config, clientSet := service.Init()
-	client.ClientSet = clientSet
 
 	cfg, err := service.InitArgs()
 	if err != nil {
 		log.Fatal("Error parsing arguments: ", err)
 	}
+
+	config, clientSet := service.Init(cfg)
+	client.ClientSet = clientSet
+
 	serverVersion, err := client.ClientSet.ServerVersion()
 	if err != nil {
 		log.Fatal("Error fetching server version: ", err)

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -34,6 +34,9 @@ type ArgConfig struct {
 	// Get the list of images from https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/conformance
 	// default registry.k8s.io/conformance:v1.28.0
 	Image string
+
+	// Kubeconfig is the path to the kubeconfig file
+	Kubeconfig string
 }
 
 func InitArgs() (*ArgConfig, error) {
@@ -43,6 +46,7 @@ func InitArgs() (*ArgConfig, error) {
 	flag.StringVar(&cfg.Skip, "skip", "", "skip specific tests. allows regular expressions.")
 	flag.StringVar(&cfg.Image, "image", containerImage,
 		"image let's you select your conformance container image of your choice. for example, for v1.28.0 version of tests, use - 'registry.k8s.io/conformance-amd64:v1.25.0'")
+	flag.StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
 
 	flag.Parse()
 

--- a/pkg/service/init_test.go
+++ b/pkg/service/init_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetKubeConfig(t *testing.T) {
+	// Test case 1: kubeconfig is empty
+	kubeconfig := ""
+	expected := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	actual := getKubeConfig(kubeconfig)
+	if actual != expected {
+		t.Errorf("Expected %s, but got %s", expected, actual)
+	}
+
+	// Test case 2: kubeconfig is set through environment variable
+	kubeconfig = "/path/to/kubeconfig"
+	os.Setenv("KUBECONFIG", kubeconfig)
+	expected = kubeconfig
+	actual = getKubeConfig("")
+	if actual != expected {
+		t.Errorf("Expected %s, but got %s", expected, actual)
+	}
+
+	// Test case 3: kubeconfig starts with "~"
+	kubeconfig = "~/custom/kubeconfig"
+	expected = filepath.Join(os.Getenv("HOME"), "custom/kubeconfig")
+	actual = getKubeConfig(kubeconfig)
+	if actual != expected {
+		t.Errorf("Expected %s, but got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
This PR adds a `--kubeconfig` option that will override the `$KUBECONFIG` or `~/.kube/config` defaults. 