### PR TITLE
updated readme with `--kubeconfig` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ Usage of bin/hydrophone:
         focus runs a specific e2e test. e.g. - sig-auth. allows regular expressions.
   -image string
         image let's you select your conformance container image of your choice. for example, for v1.28.0 version of tests, use - 'registry.k8s.io/conformance-amd64:v1.25.0' (default "registry.k8s.io/conformance:v1.28.0")
+  -kubeconfig string
+        path to the kubeconfig file
   -skip string
         skip specific tests. allows regular expressions.
 ```
 
 ## Run
 
-Ensure there is a `KUBECONFIG` environment variable specified or `$HOME/.kube/config` file present before running `hydrophone`
+Ensure there is a `KUBECONFIG` environment variable specified or `$HOME/.kube/config` file present before running `hydrophone` Alternatively, you can specify the path to the kubeconfig file with the `--kubeconfig` option.
 
 To run conformance tests use:
 ```

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -46,7 +46,7 @@ func InitArgs() (*ArgConfig, error) {
 	flag.StringVar(&cfg.Skip, "skip", "", "skip specific tests. allows regular expressions.")
 	flag.StringVar(&cfg.Image, "image", containerImage,
 		"image let's you select your conformance container image of your choice. for example, for v1.28.0 version of tests, use - 'registry.k8s.io/conformance-amd64:v1.25.0'")
-	flag.StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
+	flag.StringVar(&cfg.Kubeconfig, "kubeconfig", "", "path to the kubeconfig file.")
 
 	flag.Parse()
 


### PR DESCRIPTION
This PR updates the readme to address using the kubeconfig option as an alternate to the defaults. 