### PR TITLE
Fix actions duplicate run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test with Kind
 
-on: [push, pull_request]
+on: push
 
 env:
   KIND_VERSION: v0.20.0


### PR DESCRIPTION
I don't like how the action is currently running three times per PR (twice on pull request, once on push to main) https://github.com/dims/hydrophone/actions

This PR will make the action only run on Push whether it's during a PR or post PR to main.  

ref: https://github.com/dims/hydrophone/issues/16