### PR TITLE
Tie program exit code to pod exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/dims/hydrophone/pkg/client"
 	"github.com/dims/hydrophone/pkg/service"
@@ -51,4 +52,6 @@ func main() {
 	service.RunE2E(client.ClientSet, cfg)
 	client.PrintE2ELogs()
 	service.Cleanup(client.ClientSet)
+	log.Println("Exiting with code: ", client.ExitCode)
+	os.Exit(client.ExitCode)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ var (
 
 type Client struct {
 	ClientSet *kubernetes.Clientset
+	ExitCode  int
 }
 
 // Return a new Client


### PR DESCRIPTION
This PR makes the exit code of the program the same as the exit code of the conformance pod. 

ref: https://github.com/dims/hydrophone/issues/16