### PR TITLE
Adding gofmt stage to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           go-version: 1.21
 
+      - name: Lint
+        run: |
+          gofmt -l -s $(find . -type f -name '*.go')
+          if [[ -n $(gofmt -l -s $(find . -type f -name '*.go')) ]]; then exit 1; fi
+
       - name: Install kind
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64


### PR DESCRIPTION
This PR adds a linting stage to the CI. We need both lines to 1. show the output if any files are not properly formatted and 2. evaluate if there is any output of gofmt. If there is no output the stage succeeds, if there is an output then the stage fill fail. 

Example of failing stage: https://github.com/rjsadow/hydrophone/actions/runs/7300833583/job/19896266284#step:4:1