### PR TITLE
Change how root dir is found in `bump-k8s.sh`

### DIFF
--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -2,9 +2,8 @@
 
 set -xeuo pipefail
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-HYDROPHONE_ROOT=${SCRIPTDIR}/../
+HYDROPHONE_ROOT=$(git rev-parse --show-toplevel)
+echo "HYDROPHONE_ROOT: $HYDROPHONE_ROOT"
 
 pushd "${HYDROPHONE_ROOT}" >/dev/null
   go mod edit -json | jq -r ".Require[] | .Path | select(contains(\"k8s.io/\"))" | xargs xargs -L1 go get -d


### PR DESCRIPTION
Update how `HYDROPHONE_ROOT` is determined. This way if the script ever moves for some reason, the root path isn't relative to the script. 