### PR TITLE
Fix DryRun flag inclusion

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -170,10 +170,6 @@ func RunE2E(clientset *kubernetes.Clientset, cfg *common.ArgConfig) {
 							Name:  "E2E_USE_GO_RUNNER",
 							Value: "true",
 						},
-						{
-							Name:  "E2E_DRYRUN",
-							Value: fmt.Sprintf("%t", cfg.DryRun),
-						},
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{
@@ -205,6 +201,10 @@ func RunE2E(clientset *kubernetes.Clientset, cfg *common.ArgConfig) {
 			RestartPolicy:      v1.RestartPolicyNever,
 			ServiceAccountName: "conformance-serviceaccount",
 		},
+	}
+
+	if cfg.DryRun {
+		conformancePod.Spec.Containers[0].Env = append(conformancePod.Spec.Containers[0].Env, DryRun())
 	}
 
 	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
@@ -308,4 +308,11 @@ func Cleanup(clientset *kubernetes.Clientset) {
 		}
 	}
 	log.Printf("namespace deleted %s\n", common.Namespace)
+}
+
+func DryRun() v1.EnvVar {
+	return v1.EnvVar{
+		Name:  "E2E_DRYRUN",
+		Value: "true",
+	}
 }


### PR DESCRIPTION
This PR fixes when the `E2E_DRYRUN` variable is included in the pod spec. The conformance image checks for if the variable exists at all vs what it's set to for enabling dryrun support (https://github.com/kubernetes/kubernetes/blob/master/test/conformance/image/go-runner/cmd.go#L72-L74). Previously dryrun was included on all executions. This will fix that to only include the variable if the `--dry-run` flag is set. 