### PR TITLE
Fix order of pod termination and log download

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 		service.RunE2E(client.ClientSet, cfg)
 		client.PrintE2ELogs()
 		client.FetchFiles(config, clientSet, cfg.OutputDir)
+		client.FetchExitCode()
 		service.Cleanup(client.ClientSet)
 	}
 	log.Println("Exiting with code: ", client.ExitCode)

--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -78,23 +78,22 @@ func (c *Client) PrintE2ELogs() {
 					break loop
 				}
 			}
-			c.podExitCode(pod)
 			break
 		}
 	}
 }
 
 // Wait for pod to be in terminated state and get the exit code
-func (c *Client) podExitCode(pod *v1.Pod) {
+func (c *Client) FetchExitCode() {
 	// Watching the pod's status
 	watchInterface, err := c.ClientSet.CoreV1().Pods(common.Namespace).Watch(context.TODO(), metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", pod.Name),
+		FieldSelector: fmt.Sprintf("metadata.name=%s", common.PodName),
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println("Waiting for pod to terminate...")
+	log.Println("Waiting for pod to terminate...")
 	for event := range watchInterface.ResultChan() {
 		pod, ok := event.Object.(*v1.Pod)
 		if !ok {


### PR DESCRIPTION
fix: #59 

This PR moves the determination of the exit code to after the main loop runs and log files are exported. 